### PR TITLE
Initial RedHat support

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -38,3 +38,10 @@
   notify:
     - Restart Neutron server
     - Restart Neutron plugin OpenvSwitch agent
+
+- name: Set ML2 symlink
+  file: src=/etc/neutron/plugins/ml2/ml2_conf.ini
+        dest=/etc/neutron/plugin.ini
+        owner=root
+        group=root
+        state=link

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -1,0 +1,8 @@
+---
+- name: Set service facts
+  set_fact: neutron_plugin_agent="neutron-plugin-openvswitch-agent"
+  when: ansible_os_family == 'Debian'
+
+- name: Set service facts
+  set_fact: neutron_plugin_agent='neutron-openvswitch-agent'
+  when: ansible_os_family == 'RedHat'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,7 @@
 
 - meta: flush_handlers
 
+- include: facts.yml
 - include: packages.yml
 - include: configuration.yml
 

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -1,23 +1,6 @@
 ---
+- include: packages_redhat.yml
+  when: ansible_os_family == 'RedHat'
 
-#
-# Copyright (c) 2014 Davide Guerri <davide.guerri@gmail.com>
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-- name: Install Neutron ML2 plugin
-  apt: name="{{ item }}" state=present
-  with_items:
-    - neutron-plugin-ml2
+- include: packages_debian.yml
+  when: ansible_os_family == 'Debian'

--- a/tasks/packages_debian.yml
+++ b/tasks/packages_debian.yml
@@ -17,10 +17,7 @@
 # limitations under the License.
 #
 
-- name: Restart Neutron server
-  service: name=neutron-server state=restarted
-  ignore_errors: yes # Could not be installed
-
-- name: Restart Neutron plugin OpenvSwitch agent
-  service: name={{ neutron_plugin_agent }} state=restarted
-  ignore_errors: yes # Could not be installed
+- name: Install Neutron ML2 plugin
+  apt: name="{{ item }}" state=present
+  with_items:
+    - neutron-plugin-ml2

--- a/tasks/packages_redhat.yml
+++ b/tasks/packages_redhat.yml
@@ -1,0 +1,3 @@
+---
+- name: Install Neutron ML Plugin
+  yum: name=openstack-neutron-ml2 state=present


### PR DESCRIPTION
Matching patterns from other roles.
As per documentation, the plugin config file needs to be symlink'd
to /etc/neutron/plugin.ini
